### PR TITLE
一覧表示順序を固定するため、orderを追記

### DIFF
--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -42,7 +42,7 @@ class CountriesController < ApplicationController
 
   def get_countries
     @user = User.find(params[:user_id])
-    @countries = CountryStatus.includes(:user, :country).where(user_id: params[:user_id])
+    @countries = CountryStatus.includes(:user, :country).where(user_id: params[:user_id]).order("created_at ASC")
   end
 
   def move_to_index


### PR DESCRIPTION
# Why
一覧表示順序を固定するため
(本番環境にて、ステータス更新後に一覧表示順序が変わる)

# What
orderメソッドを追記

# Test Evidence
[![Image from Gyazo](https://i.gyazo.com/823480dc54d7def44b32447d795a6994.gif)](https://gyazo.com/823480dc54d7def44b32447d795a6994)